### PR TITLE
Issue-#4999 : fixed mark brick as NOT dirty instead of "last $key"

### DIFF
--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -118,7 +118,7 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
                 $setter = 'set' . ucfirst($type);
 
                 if ($brick instanceof DataObject\DirtyIndicatorInterface) {
-                    $brick->markFieldDirty($key, false);
+                    $brick->markFieldDirty('_self', false);
                 }
 
                 $this->model->$setter($brick);


### PR DESCRIPTION
Whenever we changed one of our objects related to objectbricks or other objects related to objectbricks the relations saved in the objectbricks had been lost because the objectbrick itself were **marked as dirty**.

The flag "marked as dirty" should not have come up after loading objects from database but the incorrect line of code did not **mark the objectbrick as NOT dirty**.
So this has to changed and we assumed it was a typo.

We created an issue: https://github.com/pimcore/pimcore/issues/4999